### PR TITLE
replace $UID w/ $EUID

### DIFF
--- a/quick-back
+++ b/quick-back
@@ -77,7 +77,7 @@ while [ "$1" != "" ]; do
 done
 
 #require sudo
-if [[ $UID != 0 ]]; then
+if [[ $EUID != 0 ]]; then
     echo "Please run with sudo:"
     echo "sudo $0 $*"
     exit 1


### PR DESCRIPTION
Some distro's sudos by default do not update UID, only EUID, which is used to determine permissions (the reason this script cares):

Good discussion here: http://askubuntu.com/questions/15853/how-can-a-script-check-if-its-being-run-as-root#30161
See also: https://en.wikipedia.org/wiki/User_identifier