### PR TITLE
umount `$dest_DEV` instead of `$DEST_PATH`

### DIFF
--- a/quick-back
+++ b/quick-back
@@ -148,7 +148,7 @@ function format
 if grep -qs $DEST_PATH /proc/mounts; then
 	if [ "$FORMAT" = "1" ]; then
 		echo "Formating destination device..."
-		if sudo umount "$DEST_PATH"; then
+		if sudo umount "$dest_DEV"; then
 			if [ "$root_TYPE" = "btrfs" ]; then
 				sudo mkfs."$root_TYPE" -f "$dest_DEV"
 			else


### PR DESCRIPTION
that way we can umount ALL mpoints of the actual device to be formatted, instead of just `/mnt/quick-back` or whatever the user passed with the` -d `option