### PR TITLE
rework defaults options, excludes into stringbuilder model

### DIFF
--- a/MANPAGE
+++ b/MANPAGE
@@ -31,6 +31,11 @@ Exempt another folder from backup (/dev, /run, /sys, /proc, and more importantly
 Run quick-back in verbose mode (display a list of all files that are being added or removed from the backup)
 .RE
 
+.B "-nd, --nodefaults " 
+.RS
+Do not use the defaults excludes - exclude only the mountpoint
+.RE
+
 .B "--force-ignore " 
 .RS
 Force backup if destination isn't a mountpoint and ignore differences between source and destination filesystem type

--- a/MANPAGE
+++ b/MANPAGE
@@ -7,6 +7,7 @@ quick-back - a simple backup program using rsync
 .SH "DESCRIPTION"
 Back up a source path to a destination path or device using rsync and format the destination drive to match the source.
 
+By default, the script excludes /boot/, /run/*, /proc/*, /tmp/*, /sys/*, /dev/*, /mnt/*, media/*. These can be disabled with the -nd, --nodefaults option described below.
 .SH "OPTIONS"
 .B "-s, --source " 
 .RI [ source_path ]
@@ -23,7 +24,7 @@ Use an alternate destination (either a /dev/XXX device or a directory path)
 .B "-e, --exclude " 
 .RI [ path ]
 .RS
-Exempt another folder from backup (/dev, /run, /sys, /proc, and more importantly /tmp already excluded)
+Exempt another folder from backup (see above for defaults excludes)
 .RE
 
 .B "-v, --verbose " 
@@ -33,7 +34,12 @@ Run quick-back in verbose mode (display a list of all files that are being added
 
 .B "-nd, --nodefaults " 
 .RS
-Do not use the defaults excludes - exclude only the mountpoint
+Do not use the defaults excludes - exclude only the destination mountpoint
+.RE
+
+.B "-d, --defaults " 
+.RS
+Use the defaults excludes (default behavior)
 .RE
 
 .B "--force-ignore " 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Also, if the directory is *neither* a mountpoint nor a device file, the the scri
 
 __The Backup__
 
-After checking the source and destination, the script proceeds to call `rsync -apx --delete --no-i-r --info=progress2` to perform the actual backup job. By default, `/dev`, `/proc`, `/boot`, `/tmp`, `/sys`, and `/run`, as well as the destination mountpoint, are excluded. A feature to exclude other mountpoints is in the works as well.
+After checking the source and destination, the script proceeds to call `rsync -apx --delete --no-i-r --info=progress2` to perform the actual backup job. The `-d, -nd` switches control whether a list (see above) of default `--excludes` are added to the command. For sanity, the destination mountpoint is always excluded. A feature to exclude other mountpoints is in the works as well.
 
 If there is a `boot` subdirectory of the source, then `boot/vmlinuz` and `boot/initramfs` will be backed up, but no other files will. On many systems, this may not be suffecient to make the backup bootable. Please ensure that you have manally verified that your backup can actually boot.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you are on another linux distro, you can install the most recent version of `
 
 `curl -O https://raw.githubusercontent.com/PenguinSnail/Quick-Back/master/install.sh && chmod +x install.sh && sudo ./install.sh`
 
+or
+
+`wget https://raw.githubusercontent.com/PenguinSnail/Quick-Back/master/install.sh && chmod +x install.sh && sudo ./install.sh`
+
 If you ever want to update `quick-back`, run the `install.sh` command again
 
 __Usage__

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or
 
 `wget https://raw.githubusercontent.com/PenguinSnail/Quick-Back/master/install.sh && chmod +x install.sh && sudo ./install.sh`
 
-If you ever want to update `quick-back`, run the `install.sh` command again
+If you ever want to update `quick-back`, run the `install.sh` command again!
 
 __Usage__
 
@@ -48,9 +48,19 @@ Options **MUST** be passed separately.
 
 `-e, --exclude <path>`: This option excludes aditional paths relative to the source directory. Multiple paths can be excluded if multiple option flags are used.
 
+`-nd, --nodefaults`: This options omits passing rsync the default excludes below (the dest. mountpoint is always excluded, as are any user specified excludes).
+
 `-v, --verbose`: This option runs `quick-back` in verbose mode, displaying every file being modified on the backup
 
 `--force-ignore`: This option will force-override the sanity checks.
+
+**Safety Options**
+
+*These options reinforce behavior that is currently the default.*
+
+`-d, --defaults`: This options ensures that `quick-back` passes rsync the default excludes below.
+
+**Default Excludes: `/boot/, /run/*, /proc/*, /tmp/*, /sys/*, /dev/*, /mnt/*, media/*`**
 
 __Sanity Checks__
 

--- a/quick-back
+++ b/quick-back
@@ -36,7 +36,7 @@ echo "  -v, --verbose | Run in verbose mode - display all files being modified w
 echo "	-e, --exclude | Exempt another folder from backup (see below for the default excludes)"
 echo "	-d, --destination | Use an alternate backup destination (accepts /dev/XXX or a path)"
 echo "	-s, --source | Use an alternate source destination"
-echo "  -nd, --nodefaults | do not exclude *anything* but the destination mountpoint by default (warning - use carefully or you will overflow your disk!)
+echo "  -nd, --nodefaults | do not exclude *anything* but the destination mountpoint by default (warning - use carefully or you will overflow your disk!)"
 echo "	--force-ignore | Force backup if destination isn't a mountpoint and ignore destination filesystem type"
 echo ""
 echo "Safety Options"

--- a/quick-back
+++ b/quick-back
@@ -10,16 +10,17 @@ DEST_PATH=/mnt/quick-back
 DEST=$DEST_PATH
 #set source path
 SRC=/
-#Set boolean values for force override, exclude directory, and FS formatting
+#Set boolean values for force override, default excludes, and FS formatting
 FORCE=0
 FORMAT=0
-BOOLEXCLUDE=0
+USEDEFAULTS=0
 #multiple rsync --excludes
 EXCLUDESNUM=0
 EXCLUDEDIR=()
-#set the default rsync options
-OPTIONS="-apx --no-i-r --info=progress2"
-
+#set the rsync options (ALWAYS used)
+OPTIONS="-apx --no-i-r --info=progress2 --delete --exclude=$DEST_PATH"
+#set the suggested rsync options, used only if -nd,--nodefaults is NOT passed
+DEFAULTS="--exclude=/boot/ --exclude=/run/* --exclude=/proc/* --exclude=/tmp/* --exclude=/sys/* --exclude=/dev/* --exclude=/mnt/* --exclude=/media/*"
 #Define functions
 
 usage () 
@@ -35,7 +36,13 @@ echo "  -v, --verbose | Run in verbose mode - display all files being modified w
 echo "	-e, --exclude | Exempt another folder from backup (/dev, /run, /sys, /proc, and more importantly /tmp already excluded)"
 echo "	-d, --destination | Use an alternate backup destination (accepts /dev/XXX or a path)"
 echo "	-s, --source | Use an alternate source destination"
+echo "  -nd, --nodefaults | do not exclude *anything* but the destination mountpoint by default (warning - use carefully or you will overflow your disk!)
 echo "	--force-ignore | Force backup if destination isn't a mountpoint and ignore destination filesystem type"
+echo ""
+echo " -- Safety Options --
+echo "NB: These options reinforce default behavior as of the version in which there are added. No changes will be made to this behavior, except for bugfixes"
+echo ""
+echo "	-d, --defaults | append the default excludes (--exclude=/boot/ --exclude=/run/* --exclude=/proc/* --exclude=/tmp/* --exclude=/sys/* --exclude=/dev/* --exclude=/mnt/* --exclude=/media/*) to the rsync command"
 }
 
 
@@ -43,20 +50,20 @@ backup ()
 {
 #backup $SRC to $DEST_PATH
 echo "Starting backup (this will take a few minutes)..."
-#if the exclude boolean is false (0) then run rsync from source to destination excluding temporary filesystems and /boot
-if [ "$BOOLEXCLUDE" = "0" ]; then
-    rsync $OPTIONS --delete --exclude=/boot/ --exclude=/run/* --exclude=/proc/* --exclude=/tmp/* --exclude=/sys/* --exclude=/dev/* --exclude=/mnt/* --exclude=/media/* --exclude=$DEST_PATH $SRC/* $DEST_PATH
-#If the exclude boolean is true (1) then run rsync from source to destination excluding temporary file systems, /boot, and the excluded path specified by command options
-elif [ "$BOOLEXCLUDE" = "1" ]; then
-    CMD="rsync $OPTIONS --delete --exclude=/boot/ --exclude=/run/* --exclude=/proc/* --exclude=/tmp/* --exclude=/sys/* --exclude=/dev/* --exclude=/mnt/* --exclude=/media/* --exclude=$DEST_PATH $SRC/* $DEST_PATH"
-		while [ "$EXCLUDESNUM" -ge 1 ]; do #LIFO queue
-			CMD="${CMD} --exclude="
-    		CMD="${CMD}${EXCLUDEDIR[$EXCLUDESNUM]}"
-			EXCLUDESNUM=$(expr $EXCLUDESNUM - 1)
-		done
-    eval "$CMD"
-
+CMD="rsync $OPTIONS $SRC/* $DEST_PATH"
+#if -nd is NOT passed, concatenate $DEFAULTS with $CMD
+if [ "$USEDEFAULTS" = "0" ]; then
+   CMD="${CMD} ${DEFAULTS}"
 fi
+#add any user specified excludes
+while [ "$EXCLUDESNUM" -ge 1 ]; do #LIFO queue
+	CMD="${CMD} --exclude="
+    	CMD="${CMD}${EXCLUDEDIR[$EXCLUDESNUM]}"
+	EXCLUDESNUM=$(expr $EXCLUDESNUM - 1)
+done
+  
+#run the job
+eval "$CMD"
 }
 
 
@@ -292,6 +299,9 @@ done < /tmp/quick-back-subvolumes
 fi
 }
 
+#
+# EXECUTION STARTS HERE 
+#
 
 #parse command options
 while [ "$1" != "" ]; do
@@ -302,17 +312,18 @@ while [ "$1" != "" ]; do
         -s | --source )         shift
                                 SRC=$1
                                 ;;
-	--force-ignore )        	FORCE=1
+	--force-ignore )        FORCE=1
                                 ;;
-	-e | --exclude )			BOOLEXCLUDE=1
-								EXCLUDESNUM=$((EXCLUDESNUM+1))
-								shift
-								EXCLUDEDIR[$EXCLUDESNUM]=$1
-								;;
+	-e | --exclude )	EXCLUDESNUM=$((EXCLUDESNUM+1))
+				shift
+				EXCLUDEDIR[$EXCLUDESNUM]=$1
+				;;
         -h | --help )           usage
                                 exit
                                 ;;
-	-v | --verbose )        	OPTIONS="-avpx"
+	-nd | --nodefaults )	USEDEFAULTS=1
+				;;
+	-v | --verbose )        OPTIONS="${OPTIONS} -v"
                                 ;;
         * )                     echo "invalid option "$1""
                                 usage
@@ -327,7 +338,6 @@ if [ "$(id -u)" != 0 ]; then
     echo "sudo $0 $*"
     exit 1
 fi
-
 
 #Call functions
 check_source

--- a/quick-back
+++ b/quick-back
@@ -33,16 +33,18 @@ echo "Default Source Directory: /"
 echo ""
 echo "	-h, --help | Dispay this help dialog"
 echo "  -v, --verbose | Run in verbose mode - display all files being modified without the progress meter"
-echo "	-e, --exclude | Exempt another folder from backup (/dev, /run, /sys, /proc, and more importantly /tmp already excluded)"
+echo "	-e, --exclude | Exempt another folder from backup (see below for the default excludes)"
 echo "	-d, --destination | Use an alternate backup destination (accepts /dev/XXX or a path)"
 echo "	-s, --source | Use an alternate source destination"
 echo "  -nd, --nodefaults | do not exclude *anything* but the destination mountpoint by default (warning - use carefully or you will overflow your disk!)
 echo "	--force-ignore | Force backup if destination isn't a mountpoint and ignore destination filesystem type"
 echo ""
-echo " -- Safety Options --
+echo "Safety Options"
 echo "NB: These options reinforce default behavior as of the version in which there are added. No changes will be made to this behavior, except for bugfixes"
 echo ""
-echo "	-d, --defaults | append the default excludes (--exclude=/boot/ --exclude=/run/* --exclude=/proc/* --exclude=/tmp/* --exclude=/sys/* --exclude=/dev/* --exclude=/mnt/* --exclude=/media/*) to the rsync command"
+echo "	-d, --defaults | append the default excludes to the rsync command"
+echo ""
+echo "Default Excludes: /boot/, /run/*, /proc/*, /tmp/*, /sys/*, /dev/*, /mnt/*, media/*"
 }
 
 


### PR DESCRIPTION
plus a little formatting

1. excludes can now be disables (except for dest mp)
--> we now have a mandatory rsync settings var and a "suggested one" with the excludes
2. pass -nd,--nodefaults to only use the former
3. I have documented, but not implemented, a -d,--defaults options - this is to keep scripting safe in case we change default behavior on an update
4. fixed apparent bug w/ -v switch